### PR TITLE
Avoid `indexerror` on results that are not movies

### DIFF
--- a/src/movieratings.py
+++ b/src/movieratings.py
@@ -30,14 +30,8 @@ def main(wf):
         wf.add_item(title = 'Nothing was found.')
       
     elif 'Search' in moviesData:
-        counter = 0
-        for movie in moviesData['Search']:
-            counter = counter + 1
-
-            # Only show a max of 5 results to spare the OMDB API
-            if counter > 5:
-                break
-
+        # Only show a max of 5 results to spare the OMDB API
+        for movie in moviesData['Search'][:5]:
             # We set a low timeout for subsequent requests to not block the execution of the script
             # That is, user input will be ignored until existing requests finish.
             timeout = 5.0

--- a/src/movieratings.py
+++ b/src/movieratings.py
@@ -42,7 +42,7 @@ def main(wf):
 
                 extendedMovieData = response.json()
                 imdbRating = extendedMovieData['imdbRating']
-                tomatoesRating = extendedMovieData['Ratings'][1]['Value']
+                tomatoesRating = extendedMovieData['Ratings'][1]['Value'] if len(extendedMovieData['Ratings']) > 1 else 'N/A'
                 subtitle = 'IMDb: %s RT: %s Metacritic: %s' % (imdbRating, tomatoesRating, extendedMovieData['Metascore'])
             except:
                 log.debug("Caught timeout exception")


### PR DESCRIPTION
OMDb only seems to return Rotten Tomatoes rating for [movies](http://www.omdbapi.com/?i=tt6723592&r=json&apikey=cfc98aff) and not for [series](http://www.omdbapi.com/?i=tt6723592&r=json&apikey=cfc98aff
) or [episodes](http://www.omdbapi.com/?i=tt7368232&r=json&apikey=cfc98aff). To prevent an exception of type `indexerror` I added a condition to check the list size (seems more appropriate in case OMDb starts to return Rotten Tomatoes rating) instead of checking if it is a movie. In any case, I'm happy to implement differently. I've also made a minor tweak to be more pythonic.